### PR TITLE
Tidy up parser testing utility functions

### DIFF
--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -181,11 +181,13 @@ struct QueryGrammar : qi::grammar<Iterator, Command(), Skipper>
   qi::rule<Iterator, Command(), Skipper> command;
 };
 
+using StringQueryGrammar = QueryGrammar<std::string::const_iterator>;
+
 struct Parser::impl
 {
   Command parse(const string& cmd);
 
-  QueryGrammar<std::string::const_iterator> grammar;
+  StringQueryGrammar grammar;
 };
 
 Command Parser::impl::parse(const string& cmd)

--- a/src/util.hpp
+++ b/src/util.hpp
@@ -79,48 +79,75 @@ auto join(Container container, const Str& sep)
 
 /* boost::qi debugging helpers */
 
-template<typename P>
-bool test_parser(char const* input, P const& p, bool full_match = true)
+template<typename I, typename P>
+bool test_parser(const I& input, P const& p, bool full_match = true)
 {
   using boost::spirit::qi::parse;
 
-  char const* f(input);
-  char const* l(f + strlen(f));
-  return (parse(f, l, p) && (!full_match || (f == l)));
+  auto b = std::begin(input);
+  auto e = std::end(input);
+  return (parse(b, e, p) && (!full_match || (b == e)));
 }
 
-template<typename P>
-bool test_phrase_parser(char const* input, P const& p, bool full_match = true)
+template<typename I, typename P>
+bool test_phrase_parser(const I& input, const P& p, bool full_match = true)
 {
   using boost::spirit::qi::phrase_parse;
   using boost::spirit::qi::ascii::space;
 
-  const std::string f(input);
-  auto b = f.begin(), e = f.end();
+  auto b = std::begin(input);
+  auto e = std::end(input);
   return (phrase_parse(b, e, p, space) && (!full_match || (b == e)));
 }
 
-template<typename P, typename T>
-bool test_parser_attr(char const* input, P const& p, T& attr,
+template<typename I, typename P, typename T>
+bool test_parser_attr(const I& input, const P& p, T& attr,
                       bool full_match = true)
 {
   using boost::spirit::qi::parse;
 
-  char const* f(input);
-  char const* l(f + strlen(f));
-  return (parse(f, l, p, attr) && (!full_match || (f == l)));
+  auto b = std::begin(input);
+  auto e = std::end(input);
+  return (parse(b, e, p, attr) && (!full_match || (b == e)));
 }
 
-template<typename P, typename T>
-bool test_phrase_parser_attr(char const* input, P const& p, T& attr,
+template<typename I, typename P, typename T>
+bool test_phrase_parser_attr(const I& input, const P& p, T& attr,
                              bool full_match = true)
 {
   using boost::spirit::qi::phrase_parse;
   using boost::spirit::qi::ascii::space;
 
-  const std::string f(input);
-  auto b = f.begin(), e = f.end();
+  auto b = std::begin(input);
+  auto e = std::end(input);
   return (phrase_parse(b, e, p, space, attr) && (!full_match || (b == e)));
+}
+
+template<size_t N, typename P, typename T>
+bool test_parser(const char (&input)[N], const P& p, bool full_match = true)
+{
+  return test_parser(std::string(input), p, full_match);
+}
+
+template<size_t N, typename P, typename T>
+bool test_phrase_parser(const char (&input)[N], const P& p,
+                        bool full_match = true)
+{
+  return test_phrase_parser(std::string(input), p, full_match);
+}
+
+template<size_t N, typename P, typename T>
+bool test_parser_attr(const char (&input)[N], const P& p, T& attr,
+                      bool full_match = true)
+{
+  return test_parser_attr(std::string(input), p, attr, full_match);
+}
+
+template<size_t N, typename P, typename T>
+bool test_phrase_parser_attr(const char (&input)[N], const P& p, T& attr,
+                             bool full_match = true)
+{
+  return test_phrase_parser_attr(std::string(input), p, attr, full_match);
 }
 
 } // namespace white::util


### PR DESCRIPTION
- Add alias for StringQueryGrammar for QueryGrammar with strings.
- Replace `const char*` with templated types.