### PR TITLE
Implement column definitions

### DIFF
--- a/src/sdl/database.cpp
+++ b/src/sdl/database.cpp
@@ -8,6 +8,34 @@ namespace white::davisbase::sdl {
 
 namespace fs = std::filesystem;
 
+static inline common::ColumnDefinitions tables_schema_column_definitions()
+{
+  using common::ColumnModifiers;
+  using common::ColumnType;
+  return {
+    {"table_name", ColumnType::TEXT, ColumnModifiers()},
+    {"root_page_no", ColumnType::INT, ColumnModifiers()},
+    {"page_count", ColumnType::INT, ColumnModifiers()},
+    {"next_row_id", ColumnType::INT, ColumnModifiers()},
+    {"page_length", ColumnType::SMALLINT, ColumnModifiers()},
+  };
+}
+
+static inline common::ColumnDefinitions columns_schema_column_definitions()
+{
+  using common::ColumnModifiers;
+  using common::ColumnType;
+  return {
+    {"table_name", ColumnType::TEXT, ColumnModifiers()},
+    {"column_name", ColumnType::TEXT, ColumnModifiers()},
+    {"data_type", ColumnType::TINYINT, ColumnModifiers()},
+    {"ordinal_position", ColumnType::TINYINT, ColumnModifiers()},
+    {"is_nullable", ColumnType::TINYINT, ColumnModifiers()},
+    {"is_primary", ColumnType::TINYINT, ColumnModifiers()},
+    {"is_unique", ColumnType::TINYINT, ColumnModifiers()},
+  };
+}
+
 template<typename T>
 static inline auto open_new_file(T&& path)
 {
@@ -35,30 +63,10 @@ Database::Database(std::filesystem::path directory_path,
   , schema_{initializeSchema()}
 {
   bootstrapping_schema_ = false;
-  std::cerr << schema_.tables << std::endl;
-  std::cerr << schema_.columns << std::endl;
 }
 
 Database::Schema Database::initializeSchema()
 {
-  /* davisbase_tables
-   *
-   * table_name TEXT,
-   * root_page_no INT,
-   * page_count INT,
-   * next_row_id INT,
-   * page_length SMALLINT
-   *
-   * davisbase_columns
-   *
-   * table_name TEXT,
-   * column_name TEXT,
-   * data_type TINYINT,
-   * ordinal_position TINYINT,
-   * is_nullable TINYINT,
-   * is_primary TINYINT
-   */
-
   static const auto tables_schema_name = std::string("davisbase_tables");
   static const auto tables_path =
     directory_path_ / (tables_schema_name + TABLE_FILE_EXT);
@@ -72,11 +80,11 @@ Database::Schema Database::initializeSchema()
 
     auto tables_schema =
       Table(*this, tables_schema_name, open_existing_file(tables_path), 0, 0, 0,
-            default_page_length_);
+            default_page_length_, tables_schema_column_definitions());
 
     auto columns_schema =
       Table(*this, columns_schema_name, open_existing_file(columns_path), 0, 0,
-            0, default_page_length_);
+            0, default_page_length_, columns_schema_column_definitions());
 
     PageNo root_page_no;
     PageCount page_count;
@@ -88,80 +96,25 @@ Database::Schema Database::initializeSchema()
 
     tables_schema =
       Table(*this, tables_schema_name, open_existing_file(tables_path),
-            root_page_no, next_row_id, page_count, page_length);
+            root_page_no, next_row_id, page_count, page_length,
+            getColumnsInfo(tables_schema_name, columns_schema));
 
     getTableInfo(columns_schema_name, root_page_no, page_count, next_row_id,
                  page_length, tables_schema);
 
     columns_schema =
-      Table(*this, columns_schema_name, open_existing_file(tables_path),
-            root_page_no, next_row_id, page_count, page_length);
+      Table(*this, columns_schema_name, open_existing_file(columns_path),
+            root_page_no, next_row_id, page_count, page_length,
+            getColumnsInfo(columns_schema_name, columns_schema));
 
     return {std::move(tables_schema), std::move(columns_schema)};
   }
 
+  using common::ColumnDefinitions;
   using common::ColumnType;
   using std::get;
   using std::make_tuple;
   using util::make_array;
-
-  // clang-format off
-  static const auto default_columns = make_array(
-    make_tuple(1, tables_schema_name, "table_name", ColumnType::TEXT, 1, false, false),
-    make_tuple(2, tables_schema_name, "root_page_no", ColumnType::INT, 2, false, false),
-    make_tuple(3, tables_schema_name, "page_count", ColumnType::INT, 3, false, false),
-    make_tuple(4, tables_schema_name, "next_row_id", ColumnType::INT, 4, false, false),
-    make_tuple(5, tables_schema_name, "page_length", ColumnType::SMALLINT, 5, false, false),
-    make_tuple(6, columns_schema_name, "table_name", ColumnType::TEXT, 1, false, false),
-    make_tuple(7, columns_schema_name, "column_name", ColumnType::TEXT, 2, false, false),
-    make_tuple(8, columns_schema_name, "data_type", ColumnType::TINYINT, 3, false, false),
-    make_tuple(9, columns_schema_name, "ordinal_position", ColumnType::TINYINT, 4, false, false),
-    make_tuple(10, columns_schema_name, "is_nullable", ColumnType::TINYINT, 5, false, false),
-    make_tuple(11, columns_schema_name, "is_primary", ColumnType::TINYINT, 6, false, false)
-  );
-
-  static const auto default_tables = make_array(
-    make_tuple(1, tables_schema_name, 3),
-    make_tuple(2, columns_schema_name, 12)
-  );
-  // clang-format on
-
-  auto append_table_to_schema = [](auto& table, auto&& table_info) {
-    constexpr auto ROOT_PAGE = 0;
-    constexpr auto PAGE_COUNT = 1;
-    auto& row_id = get<0>(table_info);
-    auto& table_name = get<1>(table_info);
-    auto& next_row_id = get<2>(table_info);
-
-    TableLeafCellPayload payload{
-      RowData{TextColumnValue(table_name), IntColumnValue(ROOT_PAGE),
-              IntColumnValue(PAGE_COUNT), IntColumnValue(next_row_id),
-              SmallIntColumnValue(table.pageLength())}};
-
-    TableLeafCell cell({payload.length(), row_id}, payload);
-
-    table.appendRecord(cell);
-  };
-
-  auto append_column_to_schema = [](auto& table, auto&& column_info) {
-    auto& row_id = get<0>(column_info);
-    auto& table_name = get<1>(column_info);
-    auto& column_name = get<2>(column_info);
-    auto data_type =
-      static_cast<TinyIntColumnValue::underlying_type>(get<3>(column_info));
-    auto& ordinal_position = get<4>(column_info);
-    auto& is_nullable = get<5>(column_info);
-    auto& is_primary = get<6>(column_info);
-
-    TableLeafCellPayload payload{RowData{
-      TextColumnValue(table_name), TextColumnValue(column_name),
-      TinyIntColumnValue(data_type), TinyIntColumnValue(ordinal_position),
-      TinyIntColumnValue(is_nullable), TinyIntColumnValue(is_primary)}};
-
-    TableLeafCell cell({payload.length(), row_id}, payload);
-
-    table.appendRecord(cell);
-  };
 
   auto tables_file = open_new_file(tables_path);
   if (!tables_file)
@@ -171,19 +124,52 @@ Database::Schema Database::initializeSchema()
   if (!columns_file)
     throw std::runtime_error("Couldn't create columns schema file");
 
-  auto tables_schema =
-    Table::create(*this, tables_schema_name, std::move(tables_file),
-                  default_tables.size() + 1, default_page_length_);
+  auto tables_schema = Table::create(
+    *this, tables_schema_name, std::move(tables_file), INITIAL_ROW_ID,
+    default_page_length_, tables_schema_column_definitions());
 
-  auto columns_schema =
-    Table::create(*this, columns_schema_name, std::move(columns_file),
-                  default_columns.size() + 1, default_page_length_);
+  auto columns_schema = Table::create(
+    *this, columns_schema_name, std::move(columns_file), INITIAL_ROW_ID,
+    default_page_length_, columns_schema_column_definitions());
 
-  for (auto& table_info : default_tables)
-    append_table_to_schema(tables_schema, table_info);
+  auto tables_columns = tables_schema_column_definitions();
+  auto columns_columns = columns_schema_column_definitions();
 
-  for (auto& column_info : default_columns)
-    append_column_to_schema(columns_schema, column_info);
+  tables_schema.appendRecord(
+    {tables_schema_name, 0, 0, 0, default_page_length_});
+
+  tables_schema.appendRecord(
+    {columns_schema_name, 0, 0, 0, default_page_length_});
+
+  for (size_t i = 0; i < tables_columns.size(); i++) {
+    auto& col = tables_columns[i];
+    columns_schema.appendRecord(
+      {tables_schema_name, col.name, col.type, i + 1, col.modifiers.is_null,
+       col.modifiers.primary_key, col.modifiers.unique});
+  }
+
+  for (size_t i = 0; i < columns_columns.size(); i++) {
+    auto& col = columns_columns[i];
+    columns_schema.appendRecord(
+      {columns_schema_name, col.name, col.type, i + 1, col.modifiers.is_null,
+       col.modifiers.primary_key, col.modifiers.unique});
+  }
+
+  tables_schema.mapOverRecords([&](TableLeafPage& page, TableLeafCell cell) {
+    using std::get;
+    if (get<TextColumnValue>(cell.row_data[0]).get() == tables_schema_name) {
+      get<IntColumnValue>(cell.row_data[1]) = tables_schema.rootPageNo();
+      get<IntColumnValue>(cell.row_data[2]) = tables_schema.pageCount();
+      get<IntColumnValue>(cell.row_data[3]) = tables_schema.nextRowId();
+      page.updateRecord(cell);
+    } else if (get<TextColumnValue>(cell.row_data[0]).get() ==
+               columns_schema_name) {
+      get<IntColumnValue>(cell.row_data[1]) = columns_schema.rootPageNo();
+      get<IntColumnValue>(cell.row_data[2]) = columns_schema.pageCount();
+      get<IntColumnValue>(cell.row_data[3]) = columns_schema.nextRowId();
+      page.updateRecord(cell);
+    }
+  });
 
   return {std::move(tables_schema), std::move(columns_schema)};
 }
@@ -201,7 +187,6 @@ void Database::getTableInfo(const std::string& table_name, PageNo& root_page_no,
                             PageLength& page_length, Table& tables_schema)
 {
   bool found = false;
-  auto page = tables_schema.leftmostLeafPage();
 
   tables_schema.mapOverRecords([&](TableLeafCell cell) {
     using std::get;
@@ -218,6 +203,36 @@ void Database::getTableInfo(const std::string& table_name, PageNo& root_page_no,
 
   if (!found)
     throw std::runtime_error("Table entry is not found on schema");
+}
+
+common::ColumnDefinitions Database::getColumnsInfo(
+  const std::string& table_name)
+{
+  return getColumnsInfo(table_name, schema_.columns);
+}
+
+common::ColumnDefinitions Database::getColumnsInfo(
+  const std::string& table_name, Table& columns_schema)
+{
+  common::ColumnDefinitions column_definitions;
+
+  columns_schema.mapOverRecords([&](TableLeafCell cell) {
+    using std::get;
+    using common::ColumnType;
+    auto& row_data = cell.row_data;
+    if (get<TextColumnValue>(cell.row_data[0]).get() == table_name) {
+      auto& col_def = column_definitions.emplace_back();
+      col_def.name = get<TextColumnValue>(row_data[1]).get();
+      col_def.type =
+        static_cast<ColumnType>(get<TinyIntColumnValue>(row_data[2]).get());
+      col_def.modifiers.is_null = get<TinyIntColumnValue>(row_data[4]).get();
+      col_def.modifiers.primary_key =
+        get<TinyIntColumnValue>(row_data[5]).get();
+      col_def.modifiers.unique = get<TinyIntColumnValue>(row_data[6]).get();
+    }
+  });
+
+  return column_definitions;
 }
 
 void Database::updatePageCount(const std::string& table_name,
@@ -251,7 +266,8 @@ void Database::updateNextRowId(const std::string& table_name, RowId next_row_id)
   });
 }
 
-Table Database::createTable(const std::string& table_name)
+Table Database::createTable(const std::string& table_name,
+                            common::ColumnDefinitions&& column_definitions)
 {
   static const auto path = directory_path_ / (table_name + TABLE_FILE_EXT);
 
@@ -262,16 +278,20 @@ Table Database::createTable(const std::string& table_name)
   if (!file)
     throw std::runtime_error("Couldn't create table file");
 
-  auto table = Table::create(*this, table_name, std::move(file), INITIAL_ROW_ID,
-                             default_page_length_);
+  auto table =
+    Table::create(*this, table_name, std::move(file), INITIAL_ROW_ID,
+                  default_page_length_, std::move(column_definitions));
 
-  RowData row_data{
-    TextColumnValue(table_name), IntColumnValue(table.rootPageNo()),
-    IntColumnValue(table.pageCount()), IntColumnValue(table.nextRowId()),
-    SmallIntColumnValue(table.pageLength())};
+  schema_.tables.appendRecord({table_name, table.rootPageNo(),
+                               table.pageCount(), table.nextRowId(),
+                               table.pageLength()});
 
-  schema_.tables.appendRecord(row_data);
-
+  for (size_t i = 0; i < table.columnDefinitions().size(); i++) {
+    auto& col = table.columnDefinitions()[i];
+    schema_.columns.appendRecord(
+      {table_name, col.name, col.type, i + 1, col.modifiers.is_null,
+       col.modifiers.primary_key, col.modifiers.unique});
+  }
   return table;
 }
 
@@ -308,7 +328,7 @@ std::optional<Table> Database::getTable(const std::string& table_name)
   getTableInfo(table_name, root_page_no, page_count, next_row_id, page_length);
 
   return Table(*this, table_name, std::move(file), root_page_no, next_row_id,
-               page_count, page_length);
+               page_count, page_length, getColumnsInfo(table_name));
 }
 
 // void Database::removeTable(string table_name) {}

--- a/src/sdl/database.hpp
+++ b/src/sdl/database.hpp
@@ -4,6 +4,7 @@
 #include <memory>
 #include <optional>
 
+#include "../common.hpp"
 #include "common.hpp"
 #include "table.hpp"
 
@@ -41,6 +42,11 @@ private:
                     PageCount& page_count, RowId& next_row_id,
                     PageLength& page_length, Table& tables_schema);
 
+  common::ColumnDefinitions getColumnsInfo(const std::string& table_name);
+
+  common::ColumnDefinitions getColumnsInfo(const std::string& table_name,
+                                           Table& columns_schema);
+
 public:
   Database(
     std::filesystem::path directory_path = std::filesystem::current_path(),
@@ -49,7 +55,8 @@ public:
   void updatePageCount(const std::string& table_name, PageCount page_count);
   void updateNextRowId(const std::string& table_name, RowId next_row_id);
 
-  Table createTable(const std::string& table_name);
+  Table createTable(const std::string& table_name,
+                    common::ColumnDefinitions&& column_definitions);
   std::optional<Table> getTable(const std::string& table_name);
   // void removeTable(std::string table_name);
 

--- a/src/sdl/table.hpp
+++ b/src/sdl/table.hpp
@@ -9,8 +9,6 @@
 
 namespace white::davisbase::sdl {
 
-using RowData = std::vector<ColumnValueVariant>;
-
 std::ostream& operator<<(std::ostream& os, const RowData& row_data);
 
 struct TableInteriorCell
@@ -187,16 +185,22 @@ private:
   RowId next_row_id_;
   PageCount page_count_;
   PageLength page_length_;
+  common::ColumnDefinitions column_definitions_;
+
+  void appendRecord(const TableLeafCell& cell);
+  TableLeafPage leftmostLeafPage();
+  TableLeafPage leafPageByRowId(RowId row_id);
 
 public:
   Table(Database& database, std::string name, std::fstream file,
         PageNo root_page_no, RowId next_row_id, PageCount page_count,
-        PageLength page_length);
+        PageLength page_length, common::ColumnDefinitions&& column_definitions);
 
   PageNo rootPageNo() const;
   RowId nextRowId() const;
   PageLength pageLength() const;
   PageCount pageCount() const;
+  const common::ColumnDefinitions& columnDefinitions() const;
 
   void setRootPageNo(PageNo page_no);
   void setNextRowId(RowId next_row_id);
@@ -204,13 +208,10 @@ public:
 
   std::variant<TableInteriorPage, TableLeafPage> getPage(PageNo page_no);
 
+  void appendRecord(const std::vector<common::LiteralValue>& values);
   void appendRecord(const RowData& rows);
   void appendRecord(RowData&& rows);
-  void appendRecord(const TableLeafCell& cell);
   void commitPage(const Page& page);
-
-  TableLeafPage leftmostLeafPage();
-  TableLeafPage leafPageByRowId(RowId row_id);
 
   template<typename Mapper>
   void mapOverLeafPages(Mapper&& mapper);
@@ -225,7 +226,8 @@ public:
   void mapOverRecords(TableLeafPage&& initialPage, Mapper&& mapper);
 
   static Table create(Database& database, std::string name, std::fstream file,
-                      RowId next_row_id, PageLength page_length);
+                      RowId next_row_id, PageLength page_length,
+                      common::ColumnDefinitions&& column_definitions);
 
   friend std::ostream& operator<<(std::ostream& os, const Table& table);
 };


### PR DESCRIPTION
Major changes:
- `database.createTable()`: Create a table with given name and column definitions.
- `table.columnDefinitions()`: Return column definitions for a table object.
- `createRowData()`: Convenience function for returning `RowData` from given `ColumnDefinitions` and `vector<LiteralValue>`.
- It is now possible to append data to a table by just calling `table.appendRecord({65, "Test data", 32})`. It will automatically convert provided data types to column values and insert it into the table. It throws exception if the provided data cannot be casted to underlying column format (well... ideally).