### PR TITLE
Revert "Fix example"

### DIFF
--- a/docs/example.md
+++ b/docs/example.md
@@ -23,13 +23,13 @@
     });
 
   /* Variation 2 */
-  table.mapOverRecords([&](TableLeafPage& page, TableLeafCell record) {
+  table.mapOverRecords([&](Page& page, TableLeafCell record) {
     std::cerr << record << std::endl;
     std::cerr << page << std::endl;
   });
 
   /* Variation 3 */
-  table.mapOverRecords([&](CellIndex i, TableLeafPage& page, TableLeafCell record) {
+  table.mapOverRecords([&](CellIndex i, Page& page, TableLeafCell record) {
     std::cerr << record << std::endl;
     std::cerr << page << std::endl;
   });


### PR DESCRIPTION
This reverts commit bea09968eefdcd88f5aed7d5849cf22783f0a12e.

- It turns out the specification wasn't consistent, and in another place
it made where clause optional. Hmphfs...