### PR TITLE
Revert "Fix update command where clause being optional"

### DIFF
--- a/src/ast.cpp
+++ b/src/ast.cpp
@@ -22,12 +22,11 @@ static bool isWhereSatisfied(const ColumnValueVariant& variant,
 
       if constexpr (std::is_same_v<T, NullValue>) {
         switch (condition.op) {
-          case OperatorType::LESS_EQUAL:
           case OperatorType::LESS:
-          case OperatorType::GREATER_EQUAL:
           case OperatorType::GREATER:
-            throw std::runtime_error(
-              "Null value can only be compared for equality");
+            return false;
+          case OperatorType::LESS_EQUAL:
+          case OperatorType::GREATER_EQUAL:
           case OperatorType::EQUAL:
             return std::holds_alternative<NullValue>(condition.literal.value);
           default:

--- a/src/ast.hpp
+++ b/src/ast.hpp
@@ -133,15 +133,17 @@ struct UpdateCommand
   std::string table_name;
   std::string column_name;
   common::LiteralValue value;
-  WhereClause condition;
+  std::optional<WhereClause> condition;
 };
 
 inline std::ostream& operator<<(std::ostream& os, const UpdateCommand& cmd)
 {
   util::OutputManipulator om(os);
-  return os << "UpdateTableCommand(table_name=\"" << cmd.table_name
-            << "\", column_name=" << cmd.column_name << ", value=" << cmd.value
-            << ", condition=" << cmd.condition << ")";
+  os << "UpdateTableCommand(table_name=\"" << cmd.table_name
+     << "\", column_name=" << cmd.column_name << ", value=" << cmd.value;
+  if (cmd.condition.has_value())
+    os << ", condition=" << cmd.condition.value();
+  return os << ")";
 }
 
 struct CreateIndexCommand

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -129,7 +129,7 @@ struct QueryGrammar : qi::grammar<Iterator, Command(), Skipper>
                   literal % ',' >> ')';
     delete_from = Q("DELETE", "FROM") >> table_name >> -where;
     update = Q("UPDATE") >> table_name >> Q("SET") >> column_name >> '=' >>
-             literal >> where;
+             literal >> -where;
 
     /* VDL */
 


### PR DESCRIPTION
This reverts commit 2f094c533175c8d5ee91426ddf1a47485c4fb2da.

- It turns out the specification wasn't consistent, and in another place
it made where clause optional. Hmphfs...